### PR TITLE
ExpressionFunctionProviderTesting.testExpressionFunctionWithNullValue…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderTesting.java
@@ -120,7 +120,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
     }
 
     @Test
-    default void testFunctionWithNullValuesFails() {
+    default void testExpressionFunctionWithNullValuesFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> this.createExpressionFunctionProvider()


### PR DESCRIPTION
…sFails was testFunctionWithNullValuesFails