### PR TITLE
ExpressionFunctionProvider.expressionFunction ExpressionFunctionName …

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProvider.java
@@ -70,12 +70,26 @@ final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvi
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
 
+        return this.expressionFunction0(
+                name.setCaseSensitivity(this.expressionFunctionNameCaseSensitivity()),
+                values,
+                context
+        );
+    }
+
+    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction0(final ExpressionFunctionName name,
+                                                                                  final List<?> values,
+                                                                                  final ProviderContext context) {
         ExpressionFunction<?, ExpressionEvaluationContext> function;
 
         final ExpressionFunctionAliasSet aliases = this.aliases;
         final ExpressionFunctionProvider provider = this.provider;
 
-        final Optional<ExpressionFunctionSelector> selector = aliases.aliasSelector(name);
+        final Optional<ExpressionFunctionSelector> selector = aliases.aliasSelector(
+                name.setCaseSensitivity(
+                        provider.expressionFunctionNameCaseSensitivity()
+                )
+        );
         if (selector.isPresent()) {
             if (false == values.isEmpty()) {
                 throw new IllegalArgumentException("Alias " + name + " should have no values");

--- a/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
@@ -120,7 +120,9 @@ final class BasicExpressionFunctionProvider implements ExpressionFunctionProvide
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
 
-        final ExpressionFunction<?, ExpressionEvaluationContext> function = this.nameToFunction.get(name);
+        final ExpressionFunction<?, ExpressionEvaluationContext> function = this.nameToFunction.get(
+                name.setCaseSensitivity(this.nameCaseSensitivity)
+        );
         if(null == function) {
             throw new UnknownExpressionFunctionException(name);
         }

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderCollection.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderCollection.java
@@ -98,7 +98,10 @@ final class ExpressionFunctionProviderCollection implements ExpressionFunctionPr
         Objects.requireNonNull(context, "context");
 
         return this.providers.get(
-                selector,
+                selector.setName(
+                        selector.name()
+                                .setCaseSensitivity(this.expressionFunctionNameCaseSensitivity)
+                ),
                 context
         );
     }
@@ -112,7 +115,7 @@ final class ExpressionFunctionProviderCollection implements ExpressionFunctionPr
         Objects.requireNonNull(context, "context");
 
         return this.providers.get(
-                name,
+                name.setCaseSensitivity(this.expressionFunctionNameCaseSensitivity),
                 values,
                 context
         );

--- a/src/main/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProvider.java
@@ -64,7 +64,9 @@ final class FilteredExpressionFunctionProvider implements ExpressionFunctionProv
                                                                                  final List<?> values,
                                                                                  final ProviderContext context) {
         return this.provider.expressionFunction(
-                this.guard.name(name),
+                this.guard.name(
+                        name.setCaseSensitivity(this.expressionFunctionNameCaseSensitivity())
+                ),
                 Objects.requireNonNull(values, "values"),
                 Objects.requireNonNull(context, "context")
         );

--- a/src/main/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProvider.java
@@ -77,7 +77,11 @@ final class FilteredMappedExpressionFunctionProvider implements ExpressionFuncti
         Objects.requireNonNull(context, "context");
 
         return this.provider.expressionFunction(
-                this.mapper.name(name),
+                this.mapper.name(
+                        name.setCaseSensitivity(
+                                this.expressionFunctionNameCaseSensitivity()
+                        )
+                ),
                 values,
                 context
         ).setName(

--- a/src/main/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProvider.java
@@ -76,7 +76,23 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
 
-        return this.provider.expressionFunction(
+        return this.expressionFunction0(
+                name.setCaseSensitivity(this.expressionFunctionNameCaseSensitivity()),
+                values,
+                context
+        );
+    }
+
+    private ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction0(final ExpressionFunctionName name,
+                                                                                   final List<?> values,
+                                                                                   final ProviderContext context) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(values, "values");
+        Objects.requireNonNull(context, "context");
+
+        final ExpressionFunctionProvider provider = this.provider;
+
+        return provider.expressionFunction(
                 this.mapper.name(name),
                 values,
                 context


### PR DESCRIPTION
…auto fix CaseSensitivity

- Closes https://github.com/mP1/walkingkooka-tree-expression-function-provider/issues/118
- ExpressionFunctionHelper is hardcoded with a CaseSensitive.INSENSITIVE comparator as required by Spreadsheets

- Unnecessary to change 118, because providers Fix the name sensitivity before use.