### PR TITLE
ExpressionFunctionProvider ExpressionEvaluationContext type parameter

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProvider.java
@@ -31,18 +31,18 @@ import java.util.Optional;
 /**
  * A {@link ExpressionFunctionProvider} that uses the given aliases definition and {@link ExpressionFunctionProvider} to present another view.
  */
-final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class AliasesExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static AliasesExpressionFunctionProvider with(final ExpressionFunctionAliasSet aliases,
-                                                  final ExpressionFunctionProvider provider) {
-        return new AliasesExpressionFunctionProvider(
+    static <C extends ExpressionEvaluationContext> AliasesExpressionFunctionProvider<C> with(final ExpressionFunctionAliasSet aliases,
+                                                                                             final ExpressionFunctionProvider<C> provider) {
+        return new AliasesExpressionFunctionProvider<>(
             Objects.requireNonNull(aliases, "aliases"),
             Objects.requireNonNull(provider, "provider")
         );
     }
 
     private AliasesExpressionFunctionProvider(final ExpressionFunctionAliasSet aliases,
-                                              final ExpressionFunctionProvider provider) {
+                                              final ExpressionFunctionProvider<C> provider) {
         this.aliases = aliases;
         this.provider = provider;
 
@@ -50,8 +50,8 @@ final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvi
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         return this.provider.expressionFunction(
             this.aliases.selector(selector),
             context
@@ -63,9 +63,9 @@ final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvi
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
@@ -77,13 +77,13 @@ final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvi
         );
     }
 
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction0(final ExpressionFunctionName name,
-                                                                                  final List<?> values,
-                                                                                  final ProviderContext context) {
-        ExpressionFunction<?, ExpressionEvaluationContext> function;
+    public ExpressionFunction<?, C> expressionFunction0(final ExpressionFunctionName name,
+                                                        final List<?> values,
+                                                        final ProviderContext context) {
+        ExpressionFunction<?, C> function;
 
         final ExpressionFunctionAliasSet aliases = this.aliases;
-        final ExpressionFunctionProvider provider = this.provider;
+        final ExpressionFunctionProvider<C> provider = this.provider;
 
         final Optional<ExpressionFunctionSelector> selector = aliases.aliasSelector(
             name.setCaseSensitivity(
@@ -127,7 +127,7 @@ final class AliasesExpressionFunctionProvider implements ExpressionFunctionProvi
         return this.provider.expressionFunctionNameCaseSensitivity();
     }
 
-    private final ExpressionFunctionProvider provider;
+    private final ExpressionFunctionProvider<C> provider;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
@@ -39,12 +39,12 @@ import java.util.stream.Collectors;
  * A simple {@link ExpressionFunctionProvider} that supports an easy approach to batches of functions using a base
  * {@link walkingkooka.net.Url} and appending the function name.
  */
-final class BasicExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class BasicExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static BasicExpressionFunctionProvider with(final AbsoluteUrl baseUrl,
-                                                final CaseSensitivity nameCaseSensitivity,
-                                                final Set<ExpressionFunction<?, ExpressionEvaluationContext>> functions) {
-        return new BasicExpressionFunctionProvider(
+    static <C extends ExpressionEvaluationContext> BasicExpressionFunctionProvider<C> with(final AbsoluteUrl baseUrl,
+                                                                                           final CaseSensitivity nameCaseSensitivity,
+                                                                                           final Set<ExpressionFunction<?, C>> functions) {
+        return new BasicExpressionFunctionProvider<>(
             Objects.requireNonNull(baseUrl, "baseUrl"),
             Objects.requireNonNull(nameCaseSensitivity, "nameCaseSensitivity"),
             Sets.immutable(
@@ -55,15 +55,15 @@ final class BasicExpressionFunctionProvider implements ExpressionFunctionProvide
 
     private BasicExpressionFunctionProvider(final AbsoluteUrl baseUrl,
                                             final CaseSensitivity nameCaseSensitivity,
-                                            final Set<ExpressionFunction<?, ExpressionEvaluationContext>> functions) {
+                                            final Set<ExpressionFunction<?, C>> functions) {
         if (functions.isEmpty()) {
             throw new IllegalArgumentException("Functions cannot be empty");
         }
 
         this.nameCaseSensitivity = nameCaseSensitivity;
 
-        final Map<ExpressionFunctionName, ExpressionFunction<?, ExpressionEvaluationContext>> nameToFunction = Maps.sorted();
-        for (final ExpressionFunction<?, ExpressionEvaluationContext> function : functions) {
+        final Map<ExpressionFunctionName, ExpressionFunction<?, C>> nameToFunction = Maps.sorted();
+        for (final ExpressionFunction<?, C> function : functions) {
             final ExpressionFunctionName name = function.name()
                 .orElseThrow(
                     () -> new IllegalArgumentException("Cannot add unnamed functions to provider")
@@ -101,8 +101,8 @@ final class BasicExpressionFunctionProvider implements ExpressionFunctionProvide
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
 
@@ -113,14 +113,14 @@ final class BasicExpressionFunctionProvider implements ExpressionFunctionProvide
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
 
-        final ExpressionFunction<?, ExpressionEvaluationContext> function = this.nameToFunction.get(
+        final ExpressionFunction<?, C> function = this.nameToFunction.get(
             name.setCaseSensitivity(this.nameCaseSensitivity)
         );
         if (null == function) {
@@ -129,7 +129,7 @@ final class BasicExpressionFunctionProvider implements ExpressionFunctionProvide
         return function;
     }
 
-    private final Map<ExpressionFunctionName, ExpressionFunction<?, ExpressionEvaluationContext>> nameToFunction;
+    private final Map<ExpressionFunctionName, ExpressionFunction<?, C>> nameToFunction;
 
     @Override
     public ExpressionFunctionInfoSet expressionFunctionInfos() {

--- a/src/main/java/walkingkooka/tree/expression/function/provider/EmptyExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/EmptyExpressionFunctionProvider.java
@@ -30,10 +30,10 @@ import java.util.Objects;
 /**
  * A {@link ExpressionFunctionProvider} that is always empty and returns no {@link ExpressionFunctionInfo} or {@link ExpressionFunction}.
  */
-final class EmptyExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class EmptyExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static EmptyExpressionFunctionProvider with(final CaseSensitivity caseSensitivity) {
-        return new EmptyExpressionFunctionProvider(
+    static <C extends ExpressionEvaluationContext> EmptyExpressionFunctionProvider<C> with(final CaseSensitivity caseSensitivity) {
+        return new EmptyExpressionFunctionProvider<>(
             Objects.requireNonNull(caseSensitivity, "caseSensitivity")
         );
     }
@@ -51,8 +51,8 @@ final class EmptyExpressionFunctionProvider implements ExpressionFunctionProvide
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
 
@@ -62,9 +62,9 @@ final class EmptyExpressionFunctionProvider implements ExpressionFunctionProvide
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProvider.java
@@ -29,20 +29,20 @@ import java.util.List;
 /**
  * A provider that supports listing available {@link ExpressionFunctionInfo} and fetching implementations by {@link ExpressionFunctionName}.
  */
-public interface ExpressionFunctionProvider extends Provider {
+public interface ExpressionFunctionProvider<C extends ExpressionEvaluationContext> extends Provider {
 
     /**
      * Getter that attempts to return a {@link ExpressionFunction} with the given {@link ExpressionFunctionSelector} or throws an {@link IllegalArgumentException}.
      */
-    ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                          final ProviderContext context);
+    ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                final ProviderContext context);
 
     /**
      * Getter that attempts to return a {@link ExpressionFunction} with the given {@link ExpressionFunctionName} or throws an {@link IllegalArgumentException}.
      */
-    ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                          final List<?> values,
-                                                                          final ProviderContext context);
+    ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                final List<?> values,
+                                                final ProviderContext context);
 
     /**
      * Returns all known {@link ExpressionFunctionInfo}.

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderDelegator.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderDelegator.java
@@ -25,11 +25,11 @@ import walkingkooka.tree.expression.function.ExpressionFunction;
 
 import java.util.List;
 
-public interface ExpressionFunctionProviderDelegator extends ExpressionFunctionProvider {
+public interface ExpressionFunctionProviderDelegator<C extends ExpressionEvaluationContext> extends ExpressionFunctionProvider<C> {
 
     @Override
-    default ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                  final ProviderContext context) {
+    default ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                        final ProviderContext context) {
         return this.expressionFunctionProvider()
             .expressionFunction(
                 selector,
@@ -38,9 +38,9 @@ public interface ExpressionFunctionProviderDelegator extends ExpressionFunctionP
     }
 
     @Override
-    default ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                  final List<?> values,
-                                                                                  final ProviderContext context) {
+    default ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                        final List<?> values,
+                                                        final ProviderContext context) {
         return this.expressionFunctionProvider()
             .expressionFunction(
                 name,
@@ -61,5 +61,5 @@ public interface ExpressionFunctionProviderDelegator extends ExpressionFunctionP
             .expressionFunctionNameCaseSensitivity();
     }
 
-    ExpressionFunctionProvider expressionFunctionProvider();
+    ExpressionFunctionProvider<C> expressionFunctionProvider();
 }

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderTesting.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderTesting.java
@@ -24,6 +24,7 @@ import walkingkooka.plugin.ProviderContext;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.plugin.ProviderTesting;
 import walkingkooka.text.CaseSensitivity;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 
@@ -31,7 +32,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionProvider> extends ProviderTesting<T> {
+public interface ExpressionFunctionProviderTesting<P extends ExpressionFunctionProvider<C>, C extends ExpressionEvaluationContext> extends ProviderTesting<P> {
 
     // expressionFunction(ExpressionFunctionSelector, ProviderContext)..................................................
 
@@ -68,7 +69,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionFails(final ExpressionFunctionProvider provider,
+    default void expressionFunctionFails(final ExpressionFunctionProvider<C> provider,
                                          final ExpressionFunctionSelector selector,
                                          final ProviderContext context) {
         assertThrows(
@@ -91,7 +92,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionAndCheck(final ExpressionFunctionProvider provider,
+    default void expressionFunctionAndCheck(final ExpressionFunctionProvider<C> provider,
                                             final ExpressionFunctionSelector selector,
                                             final ProviderContext context,
                                             final ExpressionFunction<?, ?> expected) {
@@ -195,12 +196,12 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionAndCheck(final ExpressionFunctionProvider provider,
+    default void expressionFunctionAndCheck(final ExpressionFunctionProvider<C> provider,
                                             final ExpressionFunctionName name,
                                             final List<?> values,
                                             final ProviderContext context,
                                             final ExpressionFunction<?, ?> expected) {
-        final ExpressionFunction<?, ?> function = provider.expressionFunction(
+        final ExpressionFunction<?, C> function = provider.expressionFunction(
             name,
             values,
             context
@@ -241,7 +242,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionInfosAndCheck(final ExpressionFunctionProvider provider,
+    default void expressionFunctionInfosAndCheck(final ExpressionFunctionProvider<C> provider,
                                                  final ExpressionFunctionInfo... expected) {
         this.expressionFunctionInfosAndCheck(
             provider,
@@ -258,7 +259,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionInfosAndCheck(final ExpressionFunctionProvider provider,
+    default void expressionFunctionInfosAndCheck(final ExpressionFunctionProvider<C> provider,
                                                  final ExpressionFunctionInfoSet expected) {
         this.checkEquals(
             expected,
@@ -286,7 +287,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    default void expressionFunctionNameCaseSensitivityAndCheck(final T provider,
+    default void expressionFunctionNameCaseSensitivityAndCheck(final P provider,
                                                                final CaseSensitivity expected) {
         this.checkEquals(
             expected,
@@ -294,7 +295,7 @@ public interface ExpressionFunctionProviderTesting<T extends ExpressionFunctionP
         );
     }
 
-    T createExpressionFunctionProvider();
+    P createExpressionFunctionProvider();
 
     CaseSensitivity expressionFunctionNameCaseSensitivity();
 }

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviders.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviders.java
@@ -39,8 +39,8 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see AliasesExpressionFunctionProvider}.
      */
-    public static ExpressionFunctionProvider aliases(final ExpressionFunctionAliasSet aliases,
-                                                     final ExpressionFunctionProvider provider) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> aliases(final ExpressionFunctionAliasSet aliases,
+                                                                                                final ExpressionFunctionProvider<C> provider) {
         return AliasesExpressionFunctionProvider.with(
             aliases,
             provider
@@ -50,9 +50,9 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see BasicExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider basic(final AbsoluteUrl baseUrl,
-                                                   final CaseSensitivity nameCaseSensitivity,
-                                                   final Set<ExpressionFunction<?, ExpressionEvaluationContext>> functions) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> basic(final AbsoluteUrl baseUrl,
+                                                                                              final CaseSensitivity nameCaseSensitivity,
+                                                                                              final Set<ExpressionFunction<?, C>> functions) {
         return BasicExpressionFunctionProvider.with(
             baseUrl,
             nameCaseSensitivity,
@@ -63,8 +63,8 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see ExpressionFunctionProviderCollection}
      */
-    public static ExpressionFunctionProvider collection(final CaseSensitivity expressionFunctionNameCaseSensitivity,
-                                                        final Set<ExpressionFunctionProvider> providers) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> collection(final CaseSensitivity expressionFunctionNameCaseSensitivity,
+                                                                                                   final Set<ExpressionFunctionProvider<C>> providers) {
         return ExpressionFunctionProviderCollection.with(
             expressionFunctionNameCaseSensitivity,
             providers
@@ -74,29 +74,29 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see EmptyExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider empty(final CaseSensitivity expressionFunctionNameCaseSensitivity) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> empty(final CaseSensitivity expressionFunctionNameCaseSensitivity) {
         return EmptyExpressionFunctionProvider.with(expressionFunctionNameCaseSensitivity);
     }
 
     /**
      * {@see TreeExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider expressionFunctions() {
-        return TreeExpressionFunctionProvider.INSTANCE;
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> expressionFunctions() {
+        return TreeExpressionFunctionProvider.instance();
     }
 
     /**
      * {@see FakeExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider fake() {
-        return new FakeExpressionFunctionProvider();
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> fake() {
+        return new FakeExpressionFunctionProvider<>();
     }
 
     /**
      * {@see FilteredExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider filtered(final ExpressionFunctionProvider provider,
-                                                      final ExpressionFunctionInfoSet infos) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> filtered(final ExpressionFunctionProvider<C> provider,
+                                                                                                 final ExpressionFunctionInfoSet infos) {
         return FilteredExpressionFunctionProvider.with(
             provider,
             infos
@@ -106,8 +106,8 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see FilteredMappedExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider filteredMapped(final ExpressionFunctionInfoSet infos,
-                                                            final ExpressionFunctionProvider provider) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> filteredMapped(final ExpressionFunctionInfoSet infos,
+                                                                                                       final ExpressionFunctionProvider<C> provider) {
         return FilteredMappedExpressionFunctionProvider.with(
             infos,
             provider
@@ -117,8 +117,8 @@ public final class ExpressionFunctionProviders implements PublicStaticHelper {
     /**
      * {@see MergedMappedExpressionFunctionProvider}
      */
-    public static ExpressionFunctionProvider mergedMapped(final ExpressionFunctionInfoSet infos,
-                                                          final ExpressionFunctionProvider provider) {
+    public static <C extends ExpressionEvaluationContext> ExpressionFunctionProvider<C> mergedMapped(final ExpressionFunctionInfoSet infos,
+                                                                                                     final ExpressionFunctionProvider<C> provider) {
         return MergedMappedExpressionFunctionProvider.with(
             infos,
             provider

--- a/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionSelector.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionSelector.java
@@ -125,8 +125,8 @@ public final class ExpressionFunctionSelector implements PluginSelectorLike<Expr
     /**
      * Parses the text as an expression that may contain String literals, numbers or {@link ExpressionFunctionName}.
      */
-    public ExpressionFunction<?, ExpressionEvaluationContext> evaluateValueText(final ExpressionFunctionProvider provider,
-                                                                                final ProviderContext context) {
+    public <C extends ExpressionEvaluationContext> ExpressionFunction<?, C> evaluateValueText(final ExpressionFunctionProvider<C> provider,
+                                                                                              final ProviderContext context) {
         Objects.requireNonNull(provider, "provider");
         Objects.requireNonNull(context, "context");
 

--- a/src/main/java/walkingkooka/tree/expression/function/provider/FakeExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/FakeExpressionFunctionProvider.java
@@ -25,19 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunction;
 
 import java.util.List;
 
-public class FakeExpressionFunctionProvider implements ExpressionFunctionProvider {
+public class FakeExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         throw new UnsupportedOperationException();
     }
 
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProvider.java
@@ -30,17 +30,17 @@ import java.util.Objects;
 /**
  * A {@link ExpressionFunctionProvider} that provides functions from one provider but lists more {@link ExpressionFunctionInfo}.
  */
-final class FilteredExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class FilteredExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static FilteredExpressionFunctionProvider with(final ExpressionFunctionProvider provider,
-                                                   final ExpressionFunctionInfoSet infos) {
-        return new FilteredExpressionFunctionProvider(
+    static <C extends ExpressionEvaluationContext> FilteredExpressionFunctionProvider<C> with(final ExpressionFunctionProvider<C> provider,
+                                                                                              final ExpressionFunctionInfoSet infos) {
+        return new FilteredExpressionFunctionProvider<>(
             Objects.requireNonNull(provider, "provider"),
             Objects.requireNonNull(infos, "infos")
         );
     }
 
-    private FilteredExpressionFunctionProvider(final ExpressionFunctionProvider provider,
+    private FilteredExpressionFunctionProvider(final ExpressionFunctionProvider<C> provider,
                                                final ExpressionFunctionInfoSet infos) {
         this.guard = FilteredProviderGuard.with(
             infos.names(),
@@ -51,8 +51,8 @@ final class FilteredExpressionFunctionProvider implements ExpressionFunctionProv
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         return this.provider.expressionFunction(
             this.guard.selector(selector),
             Objects.requireNonNull(context, "context")
@@ -60,9 +60,9 @@ final class FilteredExpressionFunctionProvider implements ExpressionFunctionProv
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         return this.provider.expressionFunction(
             this.guard.name(
                 name.setCaseSensitivity(this.expressionFunctionNameCaseSensitivity())
@@ -74,7 +74,7 @@ final class FilteredExpressionFunctionProvider implements ExpressionFunctionProv
 
     private final FilteredProviderGuard<ExpressionFunctionName, ExpressionFunctionSelector> guard;
 
-    private final ExpressionFunctionProvider provider;
+    private final ExpressionFunctionProvider<C> provider;
 
     @Override
     public ExpressionFunctionInfoSet expressionFunctionInfos() {

--- a/src/main/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProvider.java
@@ -31,14 +31,14 @@ import java.util.Optional;
 /**
  * A {@link ExpressionFunctionProvider} that wraps a view of new {@link ExpressionFunctionName} to a wrapped {@link ExpressionFunctionProvider}.
  */
-final class FilteredMappedExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class FilteredMappedExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static FilteredMappedExpressionFunctionProvider with(final ExpressionFunctionInfoSet infos,
-                                                         final ExpressionFunctionProvider provider) {
+    static <C extends ExpressionEvaluationContext> FilteredMappedExpressionFunctionProvider<C> with(final ExpressionFunctionInfoSet infos,
+                                                                                                    final ExpressionFunctionProvider<C> provider) {
         Objects.requireNonNull(infos, "infos");
         Objects.requireNonNull(provider, "provider");
 
-        return new FilteredMappedExpressionFunctionProvider(
+        return new FilteredMappedExpressionFunctionProvider<>(
             infos,
             provider
         );
@@ -46,7 +46,7 @@ final class FilteredMappedExpressionFunctionProvider implements ExpressionFuncti
 
 
     private FilteredMappedExpressionFunctionProvider(final ExpressionFunctionInfoSet infos,
-                                                     final ExpressionFunctionProvider provider) {
+                                                     final ExpressionFunctionProvider<C> provider) {
         this.mapper = FilteredProviderMapper.with(
             infos,
             provider.expressionFunctionInfos(),
@@ -57,8 +57,8 @@ final class FilteredMappedExpressionFunctionProvider implements ExpressionFuncti
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
 
@@ -69,9 +69,9 @@ final class FilteredMappedExpressionFunctionProvider implements ExpressionFuncti
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
@@ -97,7 +97,7 @@ final class FilteredMappedExpressionFunctionProvider implements ExpressionFuncti
     /**
      * The original wrapped {@link ExpressionFunctionProvider}.
      */
-    private final ExpressionFunctionProvider provider;
+    private final ExpressionFunctionProvider<C> provider;
 
     @Override
     public ExpressionFunctionInfoSet expressionFunctionInfos() {

--- a/src/main/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProvider.java
@@ -31,14 +31,14 @@ import java.util.Optional;
 /**
  * A {@link ExpressionFunctionProvider} that supports renamed {@link ExpressionFunctionName} before invoking a wrapped {@link ExpressionFunctionProvider}.
  */
-final class MergedMappedExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class MergedMappedExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
 
-    static MergedMappedExpressionFunctionProvider with(final ExpressionFunctionInfoSet infos,
-                                                       final ExpressionFunctionProvider provider) {
+    static <C extends ExpressionEvaluationContext> MergedMappedExpressionFunctionProvider<C> with(final ExpressionFunctionInfoSet infos,
+                                                                                                  final ExpressionFunctionProvider<C> provider) {
         Objects.requireNonNull(infos, "infos");
         Objects.requireNonNull(provider, "provider");
 
-        return new MergedMappedExpressionFunctionProvider(
+        return new MergedMappedExpressionFunctionProvider<>(
             infos,
             provider
         );
@@ -46,7 +46,7 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
 
 
     private MergedMappedExpressionFunctionProvider(final ExpressionFunctionInfoSet infos,
-                                                   final ExpressionFunctionProvider provider) {
+                                                   final ExpressionFunctionProvider<C> provider) {
         this.mapper = MergedProviderMapper.with(
             infos,
             provider.expressionFunctionInfos(),
@@ -57,8 +57,8 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
 
@@ -69,9 +69,9 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                 final List<?> values,
-                                                                                 final ProviderContext context) {
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
+                                                       final List<?> values,
+                                                       final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
@@ -83,14 +83,14 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
         );
     }
 
-    private ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction0(final ExpressionFunctionName name,
-                                                                                   final List<?> values,
-                                                                                   final ProviderContext context) {
+    private ExpressionFunction<?, C> expressionFunction0(final ExpressionFunctionName name,
+                                                         final List<?> values,
+                                                         final ProviderContext context) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(values, "values");
         Objects.requireNonNull(context, "context");
 
-        final ExpressionFunctionProvider provider = this.provider;
+        final ExpressionFunctionProvider<C> provider = this.provider;
 
         return provider.expressionFunction(
             this.mapper.name(name),
@@ -109,7 +109,7 @@ final class MergedMappedExpressionFunctionProvider implements ExpressionFunction
     /**
      * The original wrapped {@link ExpressionFunctionProvider}.
      */
-    private final ExpressionFunctionProvider provider;
+    private final ExpressionFunctionProvider<C> provider;
 
     @Override
     public ExpressionFunctionInfoSet expressionFunctionInfos() {

--- a/src/main/java/walkingkooka/tree/expression/function/provider/TreeExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/TreeExpressionFunctionProvider.java
@@ -35,12 +35,19 @@ import java.util.Objects;
 /**
  * A {@link ExpressionFunctionProvider} for {@link ExpressionFunctions}.
  */
-final class TreeExpressionFunctionProvider implements ExpressionFunctionProvider {
+final class TreeExpressionFunctionProvider<C extends ExpressionEvaluationContext> implements ExpressionFunctionProvider<C> {
+
+    /**
+     * Type safe getter.
+     */
+    static <C extends ExpressionEvaluationContext> TreeExpressionFunctionProvider<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    final static TreeExpressionFunctionProvider INSTANCE = new TreeExpressionFunctionProvider();
+    private final static TreeExpressionFunctionProvider<?> INSTANCE = new TreeExpressionFunctionProvider<>();
 
     private TreeExpressionFunctionProvider() {
         super();
@@ -76,7 +83,7 @@ final class TreeExpressionFunctionProvider implements ExpressionFunctionProvider
     private final ExpressionFunctionInfoSet infos;
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionSelector selector,
                                                                                  final ProviderContext context) {
         return selector.evaluateValueText(
             this,
@@ -85,7 +92,7 @@ final class TreeExpressionFunctionProvider implements ExpressionFunctionProvider
     }
 
     @Override
-    public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
+    public ExpressionFunction<?, C> expressionFunction(final ExpressionFunctionName name,
                                                                                  final List<?> values,
                                                                                  final ProviderContext context) {
         Objects.requireNonNull(name, "name");
@@ -94,7 +101,7 @@ final class TreeExpressionFunctionProvider implements ExpressionFunctionProvider
 
         final List<?> copy = Lists.immutable(values);
 
-        final ExpressionFunction function;
+        final ExpressionFunction<?, C> function;
 
         switch (name.value()) {
             case "name":
@@ -105,7 +112,9 @@ final class TreeExpressionFunctionProvider implements ExpressionFunctionProvider
             case "node":
                 checkNoValues(copy);
 
-                function = ExpressionFunctions.node();
+                function = Cast.to(
+                    ExpressionFunctions.node()
+                );
                 break;
             case "typeName":
                 checkNoValues(copy);

--- a/src/test/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/AliasesExpressionFunctionProviderTest.java
@@ -25,8 +25,8 @@ import walkingkooka.plugin.ProviderContext;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
-import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.FakeExpressionFunction;
 import walkingkooka.tree.expression.function.UnknownExpressionFunctionException;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-public final class AliasesExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<AliasesExpressionFunctionProvider> {
+public final class AliasesExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<AliasesExpressionFunctionProvider<FakeExpressionEvaluationContext>, FakeExpressionEvaluationContext> {
 
     private final static String NAME1_STRING = "function1";
 
@@ -47,14 +47,14 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
     private final static ExpressionFunctionName ALIAS2 = ExpressionFunctionName.with("alias2")
         .setCaseSensitivity(ExpressionFunctionPluginHelper.INSTANCE.caseSensitivity);
 
-    private final static ExpressionFunction<?, ExpressionEvaluationContext> FUNCTION1 = function(NAME1);
+    private final static ExpressionFunction<?, FakeExpressionEvaluationContext> FUNCTION1 = function(NAME1);
 
     private final static String NAME2_STRING = "function2";
 
     private final static ExpressionFunctionName NAME2 = ExpressionFunctionName.with(NAME2_STRING)
         .setCaseSensitivity(ExpressionFunctionPluginHelper.INSTANCE.caseSensitivity);
 
-    private final static ExpressionFunction<?, ExpressionEvaluationContext> FUNCTION2 = function(NAME2);
+    private final static ExpressionFunction<?, FakeExpressionEvaluationContext> FUNCTION2 = function(NAME2);
 
     private final static ExpressionFunctionInfo INFO2 = ExpressionFunctionInfo.parse("https://example.com/function2 " + NAME2);
 
@@ -63,7 +63,7 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
     private final static ExpressionFunctionName NAME3 = ExpressionFunctionName.with(NAME3_STRING)
         .setCaseSensitivity(ExpressionFunctionPluginHelper.INSTANCE.caseSensitivity);
 
-    private final static ExpressionFunction<?, ExpressionEvaluationContext> FUNCTION3 = function(NAME3);
+    private final static ExpressionFunction<?, FakeExpressionEvaluationContext> FUNCTION3 = function(NAME3);
 
     private final static ExpressionFunctionInfo INFO3 = ExpressionFunctionInfo.parse("https://example.com/function3 " + NAME3);
 
@@ -76,7 +76,7 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
 
     private final static ExpressionFunctionInfo INFO4 = ExpressionFunctionInfo.parse("https://example.com/custom4 " + NAME4);
 
-    private static ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionFunctionName name) {
+    private static ExpressionFunction<?, FakeExpressionEvaluationContext> function(final ExpressionFunctionName name) {
         return new FakeExpressionFunction<>() {
             @Override
             public Optional<ExpressionFunctionName> name() {
@@ -84,7 +84,7 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
             }
 
             @Override
-            public ExpressionFunction<Object, ExpressionEvaluationContext> setName(final Optional<ExpressionFunctionName> n) {
+            public ExpressionFunction<Object, FakeExpressionEvaluationContext> setName(final Optional<ExpressionFunctionName> n) {
                 Objects.requireNonNull(n, "name");
 
                 return this.name().equals(n) ?
@@ -222,10 +222,10 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
 
         return AliasesExpressionFunctionProvider.with(
             ExpressionFunctionAliasSet.parse(aliases),
-            new FakeExpressionFunctionProvider() {
+            new FakeExpressionFunctionProvider<FakeExpressionEvaluationContext>() {
                 @Override
-                public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                             final ProviderContext context) {
+                public ExpressionFunction<?, FakeExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
+                                                                                                 final ProviderContext context) {
                     return selector.evaluateValueText(
                         this,
                         context
@@ -233,10 +233,10 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
                 }
 
                 @Override
-                public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                             final List<?> values,
-                                                                                             final ProviderContext context) {
-                    ExpressionFunction<?, ExpressionEvaluationContext> function;
+                public ExpressionFunction<?, FakeExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
+                                                                                                 final List<?> values,
+                                                                                                 final ProviderContext context) {
+                    ExpressionFunction<?, FakeExpressionEvaluationContext> function;
 
                     switch (name.toString()) {
                         case NAME1_STRING:
@@ -285,8 +285,8 @@ public final class AliasesExpressionFunctionProviderTest implements ExpressionFu
     // class............................................................................................................
 
     @Override
-    public Class<AliasesExpressionFunctionProvider> type() {
-        return AliasesExpressionFunctionProvider.class;
+    public Class<AliasesExpressionFunctionProvider<FakeExpressionEvaluationContext>> type() {
+        return Cast.to(AliasesExpressionFunctionProvider.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProviderTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
@@ -27,8 +28,8 @@ import walkingkooka.plugin.ProviderContext;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
-import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.FakeExpressionFunction;
 
@@ -39,8 +40,8 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class BasicExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<BasicExpressionFunctionProvider>,
-    ToStringTesting<BasicExpressionFunctionProvider> {
+public final class BasicExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<BasicExpressionFunctionProvider<FakeExpressionEvaluationContext>, FakeExpressionEvaluationContext>,
+    ToStringTesting<BasicExpressionFunctionProvider<FakeExpressionEvaluationContext>> {
 
     private final static AbsoluteUrl BASE_URL = Url.parseAbsolute("https://example.com/base/");
 
@@ -52,20 +53,20 @@ public final class BasicExpressionFunctionProviderTest implements ExpressionFunc
     private final static ExpressionFunctionName NAME2 = ExpressionFunctionName.with("testExpressionFunction2")
         .setCaseSensitivity(CASE_SENSITIVITY);
 
-    private static final FakeExpressionFunction FUNCTION1 = new FakeExpressionFunction() {
+    private static final FakeExpressionFunction<Object, FakeExpressionEvaluationContext> FUNCTION1 = new FakeExpressionFunction<>() {
         @Override
         public Optional<ExpressionFunctionName> name() {
             return Optional.of(NAME1);
         }
     };
-    private static final FakeExpressionFunction FUNCTION2 = new FakeExpressionFunction() {
+    private static final FakeExpressionFunction<Object, FakeExpressionEvaluationContext> FUNCTION2 = new FakeExpressionFunction<>() {
         @Override
         public Optional<ExpressionFunctionName> name() {
             return Optional.of(NAME2);
         }
     };
 
-    private final static Set<ExpressionFunction<?, ExpressionEvaluationContext>> FUNCTIONS = Sets.of(
+    private final static Set<ExpressionFunction<?, FakeExpressionEvaluationContext>> FUNCTIONS = Sets.of(
         FUNCTION1,
         FUNCTION2
     );
@@ -282,8 +283,8 @@ public final class BasicExpressionFunctionProviderTest implements ExpressionFunc
     // class............................................................................................................
 
     @Override
-    public Class<BasicExpressionFunctionProvider> type() {
-        return BasicExpressionFunctionProvider.class;
+    public Class<BasicExpressionFunctionProvider<FakeExpressionEvaluationContext>> type() {
+        return Cast.to(BasicExpressionFunctionProvider.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/EmptyExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/EmptyExpressionFunctionProviderTest.java
@@ -18,13 +18,15 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class EmptyExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<EmptyExpressionFunctionProvider> {
+public final class EmptyExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<EmptyExpressionFunctionProvider<FakeExpressionEvaluationContext>, FakeExpressionEvaluationContext> {
 
     @Test
     public void testWithNullCaseSensitivityFails() {
@@ -35,7 +37,7 @@ public final class EmptyExpressionFunctionProviderTest implements ExpressionFunc
     }
 
     @Override
-    public EmptyExpressionFunctionProvider createExpressionFunctionProvider() {
+    public EmptyExpressionFunctionProvider<FakeExpressionEvaluationContext> createExpressionFunctionProvider() {
         return EmptyExpressionFunctionProvider.with(ExpressionFunctionName.DEFAULT_CASE_SENSITIVITY);
     }
 
@@ -47,8 +49,8 @@ public final class EmptyExpressionFunctionProviderTest implements ExpressionFunc
     // class............................................................................................................
 
     @Override
-    public Class<EmptyExpressionFunctionProvider> type() {
-        return EmptyExpressionFunctionProvider.class;
+    public Class<EmptyExpressionFunctionProvider<FakeExpressionEvaluationContext>> type() {
+        return Cast.to(EmptyExpressionFunctionProvider.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderCollectionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/ExpressionFunctionProviderCollectionTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
@@ -29,6 +30,7 @@ import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 import walkingkooka.tree.expression.function.FakeExpressionFunction;
 
 import java.util.List;
@@ -36,8 +38,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ExpressionFunctionProviderCollectionTest implements ExpressionFunctionProviderTesting<ExpressionFunctionProviderCollection>,
-    ToStringTesting<ExpressionFunctionProviderCollection> {
+public final class ExpressionFunctionProviderCollectionTest implements ExpressionFunctionProviderTesting<ExpressionFunctionProviderCollection<FakeExpressionEvaluationContext>, FakeExpressionEvaluationContext>,
+    ToStringTesting<ExpressionFunctionProviderCollection<FakeExpressionEvaluationContext>> {
 
     private final static AbsoluteUrl BASE_URL = Url.parseAbsolute("https://example.com/base/");
 
@@ -45,13 +47,13 @@ public final class ExpressionFunctionProviderCollectionTest implements Expressio
 
     private final static ExpressionFunctionName NAME2 = ExpressionFunctionName.with("testfunction2");
 
-    private static final FakeExpressionFunction FUNCTION1 = new FakeExpressionFunction() {
+    private static final FakeExpressionFunction<Object, FakeExpressionEvaluationContext> FUNCTION1 = new FakeExpressionFunction<>() {
         @Override
         public Optional<ExpressionFunctionName> name() {
             return Optional.of(NAME1);
         }
     };
-    private static final FakeExpressionFunction FUNCTION2 = new FakeExpressionFunction() {
+    private static final FakeExpressionFunction<Object, FakeExpressionEvaluationContext> FUNCTION2 = new FakeExpressionFunction<>() {
         @Override
         public Optional<ExpressionFunctionName> name() {
             return Optional.of(NAME2);
@@ -251,8 +253,8 @@ public final class ExpressionFunctionProviderCollectionTest implements Expressio
     // class............................................................................................................
 
     @Override
-    public Class<ExpressionFunctionProviderCollection> type() {
-        return ExpressionFunctionProviderCollection.class;
+    public Class<ExpressionFunctionProviderCollection<FakeExpressionEvaluationContext>> type() {
+        return Cast.to(ExpressionFunctionProviderCollection.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/FilteredExpressionFunctionProviderTest.java
@@ -18,19 +18,21 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.plugin.ProviderContext;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
 import walkingkooka.tree.expression.function.ExpressionFunctions;
 
 import java.util.List;
 
-public final class FilteredExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<FilteredExpressionFunctionProvider>,
-    ToStringTesting<FilteredExpressionFunctionProvider> {
+public final class FilteredExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<FilteredExpressionFunctionProvider<ExpressionEvaluationContext>, ExpressionEvaluationContext>,
+    ToStringTesting<FilteredExpressionFunctionProvider<ExpressionEvaluationContext>> {
 
     private final static ProviderContext CONTEXT = ProviderContexts.fake();
 
@@ -125,8 +127,10 @@ public final class FilteredExpressionFunctionProviderTest implements ExpressionF
     // class............................................................................................................
 
     @Override
-    public Class<FilteredExpressionFunctionProvider> type() {
-        return FilteredExpressionFunctionProvider.class;
+    public Class<FilteredExpressionFunctionProvider<ExpressionEvaluationContext>> type() {
+        return Cast.to(
+            FilteredExpressionFunctionProvider.class
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/FilteredMappedExpressionFunctionProviderTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.net.AbsoluteUrl;
@@ -26,8 +27,8 @@ import walkingkooka.plugin.ProviderContext;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
-import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.FakeExpressionFunction;
 
@@ -36,8 +37,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class FilteredMappedExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<FilteredMappedExpressionFunctionProvider>,
-    ToStringTesting<FilteredMappedExpressionFunctionProvider> {
+public final class FilteredMappedExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<FilteredMappedExpressionFunctionProvider<FakeExpressionEvaluationContext>, FakeExpressionEvaluationContext>,
+    ToStringTesting<FilteredMappedExpressionFunctionProvider<FakeExpressionEvaluationContext>> {
 
     private final static AbsoluteUrl URL = Url.parseAbsolute("https://example.com/function123");
 
@@ -47,8 +48,8 @@ public final class FilteredMappedExpressionFunctionProviderTest implements Expre
     private final static ExpressionFunctionName ORIGINAL_NAME = ExpressionFunctionName.with("original-function-123")
         .setCaseSensitivity(ExpressionFunctionPluginHelper.INSTANCE.caseSensitivity);
 
-    private static ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionFunctionName name) {
-        return new FakeExpressionFunction() {
+    private static ExpressionFunction<?, FakeExpressionEvaluationContext> function(final ExpressionFunctionName name) {
+        return new FakeExpressionFunction<>() {
             @Override
             public Optional<ExpressionFunctionName> name() {
                 return Optional.of(name);
@@ -156,12 +157,12 @@ public final class FilteredMappedExpressionFunctionProviderTest implements Expre
                     NAME
                 )
             ),
-            new FakeExpressionFunctionProvider() {
+            new FakeExpressionFunctionProvider<FakeExpressionEvaluationContext>() {
 
                 @Override
-                public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
-                                                                                             final List<?> values,
-                                                                                             final ProviderContext context) {
+                public ExpressionFunction<?, FakeExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
+                                                                                                 final List<?> values,
+                                                                                                 final ProviderContext context) {
                     if (false == name.equals(ORIGINAL_NAME)) {
                         throw new IllegalArgumentException("Unknown function " + name);
                     }
@@ -169,8 +170,8 @@ public final class FilteredMappedExpressionFunctionProviderTest implements Expre
                 }
 
                 @Override
-                public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
-                                                                                             final ProviderContext context) {
+                public ExpressionFunction<?, FakeExpressionEvaluationContext> expressionFunction(final ExpressionFunctionSelector selector,
+                                                                                                 final ProviderContext context) {
                     return selector.evaluateValueText(
                         this,
                         context
@@ -214,8 +215,8 @@ public final class FilteredMappedExpressionFunctionProviderTest implements Expre
     // class............................................................................................................
 
     @Override
-    public Class<FilteredMappedExpressionFunctionProvider> type() {
-        return FilteredMappedExpressionFunctionProvider.class;
+    public Class<FilteredMappedExpressionFunctionProvider<FakeExpressionEvaluationContext>> type() {
+        return Cast.to(FilteredMappedExpressionFunctionProvider.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/MergedMappedExpressionFunctionProviderTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
@@ -37,8 +38,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class MergedMappedExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<MergedMappedExpressionFunctionProvider>,
-    ToStringTesting<MergedMappedExpressionFunctionProvider> {
+public final class MergedMappedExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<MergedMappedExpressionFunctionProvider<ExpressionEvaluationContext>, ExpressionEvaluationContext>,
+    ToStringTesting<MergedMappedExpressionFunctionProvider<ExpressionEvaluationContext>> {
 
     private final static AbsoluteUrl RENAMED_URL = Url.parseAbsolute("https://example.com/renamed-function111");
 
@@ -54,7 +55,7 @@ public final class MergedMappedExpressionFunctionProviderTest implements Express
         .setCaseSensitivity(ExpressionFunctionPluginHelper.INSTANCE.caseSensitivity);
 
     private static ExpressionFunction<?, ExpressionEvaluationContext> function(final ExpressionFunctionName name) {
-        return new FakeExpressionFunction() {
+        return new FakeExpressionFunction<>() {
             @Override
             public Optional<ExpressionFunctionName> name() {
                 return Optional.of(name);
@@ -188,7 +189,7 @@ public final class MergedMappedExpressionFunctionProviderTest implements Express
                     )
                 )
             ),
-            new FakeExpressionFunctionProvider() {
+            new FakeExpressionFunctionProvider<>() {
 
                 @Override
                 public ExpressionFunction<?, ExpressionEvaluationContext> expressionFunction(final ExpressionFunctionName name,
@@ -254,8 +255,8 @@ public final class MergedMappedExpressionFunctionProviderTest implements Express
     // class............................................................................................................
 
     @Override
-    public Class<MergedMappedExpressionFunctionProvider> type() {
-        return MergedMappedExpressionFunctionProvider.class;
+    public Class<MergedMappedExpressionFunctionProvider<ExpressionEvaluationContext>> type() {
+        return Cast.to(MergedMappedExpressionFunctionProvider.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/provider/TreeExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/TreeExpressionFunctionProviderTest.java
@@ -18,17 +18,19 @@
 package walkingkooka.tree.expression.function.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.plugin.ProviderContexts;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CaseSensitivity;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionFunctionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctions;
 
-public final class TreeExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<TreeExpressionFunctionProvider>,
-    ToStringTesting<TreeExpressionFunctionProvider> {
+public final class TreeExpressionFunctionProviderTest implements ExpressionFunctionProviderTesting<TreeExpressionFunctionProvider<ExpressionEvaluationContext>, ExpressionEvaluationContext>,
+    ToStringTesting<TreeExpressionFunctionProvider<ExpressionEvaluationContext>> {
 
     @Test
     public void testExpressionFunctionNode() {
@@ -62,8 +64,8 @@ public final class TreeExpressionFunctionProviderTest implements ExpressionFunct
     }
 
     @Override
-    public TreeExpressionFunctionProvider createExpressionFunctionProvider() {
-        return TreeExpressionFunctionProvider.INSTANCE;
+    public TreeExpressionFunctionProvider<ExpressionEvaluationContext> createExpressionFunctionProvider() {
+        return TreeExpressionFunctionProvider.instance();
     }
 
     @Override
@@ -84,8 +86,8 @@ public final class TreeExpressionFunctionProviderTest implements ExpressionFunct
     // class............................................................................................................
 
     @Override
-    public Class<TreeExpressionFunctionProvider> type() {
-        return TreeExpressionFunctionProvider.class;
+    public Class<TreeExpressionFunctionProvider<ExpressionEvaluationContext>> type() {
+        return Cast.to(TreeExpressionFunctionProvider.class);
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-expression-function-provider/issues/177
- ExpressionFunctionProvider add a type parameter that extends ExpressionEvaluationContext