### PR TITLE
BasicExpressionFunctionProvider.nameToFunction CaseSensitivity nameCa…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
@@ -62,7 +62,10 @@ final class BasicExpressionFunctionProvider<C extends ExpressionEvaluationContex
 
         this.nameCaseSensitivity = nameCaseSensitivity;
 
-        final Map<ExpressionFunctionName, ExpressionFunction<?, C>> nameToFunction = Maps.sorted();
+        final Map<ExpressionFunctionName, ExpressionFunction<?, C>> nameToFunction = Maps.sorted(
+            ExpressionFunctionName.comparator(nameCaseSensitivity)
+        );
+
         for (final ExpressionFunction<?, C> function : functions) {
             final ExpressionFunctionName name = function.name()
                 .orElseThrow(


### PR DESCRIPTION
…seSensitivity

- Closes https://github.com/mP1/walkingkooka-tree-expression-function-provider/issues/178
- BasicExpressionFunctionProvider#nameToFunction should use CaseSensitivity nameCaseSensitivity