### PR TITLE
BasicExpressionFunctionProvider duplicate name detect fails

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
+++ b/src/main/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProvider.java
@@ -71,13 +71,17 @@ final class BasicExpressionFunctionProvider<C extends ExpressionEvaluationContex
                 .orElseThrow(
                     () -> new IllegalArgumentException("Cannot add unnamed functions to provider")
                 );
-            nameToFunction.put(
+            final ExpressionFunction<?, ?> duplicate = nameToFunction.put(
                 name.setCaseSensitivity(nameCaseSensitivity),
                 function.setName(
                     function.name()
                         .map(n -> n.setCaseSensitivity(nameCaseSensitivity))
                 )
             );
+
+            if(null != duplicate) {
+                throw new IllegalArgumentException("Duplicate function " + name);
+            }
         }
 
         this.nameToFunction = nameToFunction;

--- a/src/test/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProviderTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/provider/BasicExpressionFunctionProviderTest.java
@@ -121,6 +121,90 @@ public final class BasicExpressionFunctionProviderTest implements ExpressionFunc
         );
     }
 
+    @Test
+    public void testWithDuplicateFunctionCaseSensitiveFails() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> BasicExpressionFunctionProvider.with(
+                BASE_URL,
+                CaseSensitivity.SENSITIVE,
+                Sets.of(
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("A1")
+                            );
+                        }
+                    },
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("B2")
+                            );
+                        }
+                    },
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("A1")
+                            );
+                        }
+                    }
+                )
+            )
+        );
+
+        this.checkEquals(
+            "Duplicate function A1",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testWithDuplicateFunctionCaseInsensitiveFails() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> BasicExpressionFunctionProvider.with(
+                BASE_URL,
+                CaseSensitivity.INSENSITIVE,
+                Sets.of(
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("A1")
+                            );
+                        }
+                    },
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("B2")
+                            );
+                        }
+                    },
+                    new FakeExpressionFunction<>() {
+                        @Override
+                        public Optional<ExpressionFunctionName> name() {
+                            return Optional.of(
+                                ExpressionFunctionName.with("a1")
+                            );
+                        }
+                    }
+                )
+            )
+        );
+
+        this.checkEquals(
+            "Duplicate function a1",
+            thrown.getMessage()
+        );
+    }
+
     private final static List<?> VALUES = Lists.empty();
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-expression-function-provider/issues/204
- ExpressionFunctionProviders.basic should detect and fail on duplicates